### PR TITLE
Fix #3101: Discard-draft tooltip was not showing up

### DIFF
--- a/core/templates/dev/head/pages/exploration_editor/exploration_save_and_publish_buttons_directive.html
+++ b/core/templates/dev/head/pages/exploration_editor/exploration_save_and_publish_buttons_directive.html
@@ -59,7 +59,7 @@
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu" style="min-width: 125px; right: inherit;" ng-style="{ width: getChangeListLength() && !isPrivate() ? '150px' : '120px' }">
-          <li><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="protractor-test-discard-changes" title="Discard all pending changes.">Discard Draft</a></li>
+          <li title="Discard all pending changes"><a ng-click="discardChanges()" ng-class="{'oppia-disabled-link': !getChangeListLength()}" class="protractor-test-discard-changes">Discard Draft</a></li>
         </ul>
       </div>
     </li>


### PR DESCRIPTION
The `<a> `tag prevented the discard draft tooltip which resulted in same tool tips for both Save and Discard. This is a fix.

**How to produce the error**?
-  Create a new exploration.
- Hover over the Save Draft, this should pop up **"Save draft"** tooltip. Now hover over Discard Draft button which is a drop down, you will get same tooltip **"Save draft"**

**How I found solution?**
-  #3101 as discussed in this issue I thought its a tooltip CSS/hover problem, but after going through code base there was [special tooltip for Discard draft](https://github.com/oppia/oppia/blob/develop/core/templates/dev/head/pages/exploration_editor/exploration_save_and_publish_buttons_directive.html#L62), where it was assigned near `<a>` tag which caused problem, the hover wasn't registered hence there was no tooltip.

I have placed the coded tooltip (`title="Discard all pending changes"`) where it fit our expected behaviour 

**Before PR** 
![screenshot from 2017-03-15 23-34-11](https://cloud.githubusercontent.com/assets/24438869/23963850/985a1b22-09d8-11e7-8212-bb5e384bce78.png)
![screenshot from 2017-03-15 23-34-16](https://cloud.githubusercontent.com/assets/24438869/23963849/98566cc0-09d8-11e7-870d-138923acf902.png)

**This PRs' commit**
![screenshot from 2017-03-15 23-39-49](https://cloud.githubusercontent.com/assets/24438869/23963885/b63b79a6-09d8-11e7-80cb-224d6cb18d4e.png)
![screenshot from 2017-03-15 23-39-54](https://cloud.githubusercontent.com/assets/24438869/23963884/b63a9c8e-09d8-11e7-9022-bcc7ea57823c.png)


